### PR TITLE
Fix multiple packages in the same path error

### DIFF
--- a/recipe/fix-multiple-pkgs.patch
+++ b/recipe/fix-multiple-pkgs.patch
@@ -1,0 +1,14 @@
+diff --git a/src/catkin_pkg/packages.py b/src/catkin_pkg/packages.py
+index aa7208b..ddbb435 100644
+--- a/src/catkin_pkg/packages.py
++++ b/src/catkin_pkg/packages.py
+@@ -60,7 +60,8 @@ def find_package_paths(basepath, exclude_paths=None, exclude_subspaces=False):
+     for dirpath, dirnames, filenames in os.walk(basepath, followlinks=True):
+         if set(dirnames + filenames) & {'AMENT_IGNORE', 'CATKIN_IGNORE', 'COLCON_IGNORE'} or \
+             os.path.realpath(dirpath) in real_exclude_paths or \
+-                (exclude_subspaces and '.catkin' in filenames):
++                (exclude_subspaces and '.catkin' in filenames) or \
++                os.path.relpath(dirpath, basepath).startswith('pkgs/'):
+             del dirnames[:]
+             continue
+         elif PACKAGE_MANIFEST_FILENAME in filenames:


### PR DESCRIPTION
See https://github.com/RoboStack/ros-noetic/issues/163

This has been annoying me for a long time. It's unique to conda. This should also fix issues if robostack packages are installed in the base env. The error has been popping up here and there ..

/cc @jmount1992